### PR TITLE
Fix hotreloadability

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,5 @@
-add_test(NAME tuple_keydef.test.lua
-         COMMAND runtest.sh tuple_keydef.test.lua)
+add_test(
+    NAME tuple_keydef.test.lua
+    COMMAND runtest.sh tuple_keydef.test.lua
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/test/tuple_keydef.test.lua
+++ b/test/tuple_keydef.test.lua
@@ -241,7 +241,7 @@ local tuple_keydef_new_cases = {
 
 local test = tap.test('tuple.keydef')
 
-test:plan(#tuple_keydef_new_cases - 1 + 9)
+test:plan(#tuple_keydef_new_cases - 1 + 10)
 for _, case in ipairs(tuple_keydef_new_cases) do
     if type(case) == 'function' then
         case()
@@ -626,6 +626,23 @@ test:test('no segfault at incorrect key in :compare_with_key()', function(test)
                           {1, 2, 3, 4, 5, 6, 7, 8, 9})
     test:is_deeply({ok, tostring(res)}, {false, exp_err},
                    'Invalid key part count')
+end)
+
+-- gh-9: test hotreloadability
+-- https://github.com/tarantool/tuple-keydef/issues/9
+test:test('hotreload', function(test)
+    test:plan(2)
+
+    _G.tuple = nil
+    tuple_keydef = nil
+    package.loaded['tuple.keydef'] = nil
+    collectgarbage()
+    collectgarbage()
+
+    tuple_keydef = require('tuple.keydef')
+
+    test:istable(tuple_keydef, 'tuple.keydef hotreload')
+    test:istable(_G.tuple, 'tuple hotreload')
 end)
 
 os.exit(test:check() and 0 or 1)

--- a/tuple/keydef.c
+++ b/tuple/keydef.c
@@ -636,18 +636,6 @@ lbox_key_def_new(struct lua_State *L)
 LUA_API int
 luaopen_tuple_keydef(struct lua_State *L)
 {
-	/*
-	 * ffi.metatype() cannot be called twice on the same type.
-	 *
-	 * Tarantool has built-in key_def Lua module since
-	 * 2.2.0-255-g22db9c264, which already calls
-	 * ffi.metatype() on <struct key_def>. We should use
-	 * another name within the external module.
-	 */
-	luaL_cdef(L, "struct tuple_keydef;");
-	CTID_STRUCT_TUPLE_KEY_DEF_REF =
-		luaL_ctypeid(L, "struct tuple_keydef *");
-
 	JSON_PATH_IS_SUPPORTED = json_path_is_supported();
 
 	/* Export C functions to Lua. */
@@ -664,6 +652,8 @@ luaopen_tuple_keydef(struct lua_State *L)
 
 	/* Execute Lua part of the module. */
 	execute_postload_lua(L);
+	CTID_STRUCT_TUPLE_KEY_DEF_REF =
+		luaL_ctypeid(L, "struct tuple_keydef *");
 
 	return 1;
 }

--- a/tuple/postload.lua
+++ b/tuple/postload.lua
@@ -1,4 +1,19 @@
 local ffi = require('ffi')
+
+-- Gracefully handle hotreload. If the `tuple_keydef` is already
+-- declared in FFI, then it's the hotreload case.
+-- ffi.metatype() cannot be called twice on the same type.
+if pcall(ffi.typeof, 'struct tuple_keydef') then
+    return
+end
+
+--
+-- Tarantool has built-in key_def Lua module since
+-- 2.2.0-255-g22db9c264, which already calls
+-- ffi.metatype() on <struct key_def>. We should use
+-- another name within the external module.
+ffi.cdef('struct tuple_keydef;')
+
 local tuple_keydef = require('tuple.keydef')
 local tuple_keydef_t = ffi.typeof('struct tuple_keydef')
 


### PR DESCRIPTION
Gracefully handle hotreload. It didn't work because `postload.lua` always tried to call `ffi.metatype()`, but luajit doesn't allow to do it twice for the same type.

Fixes #9.