### PR TITLE
test: fix 'make test' in out-of-source build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,13 @@
-add_test(NAME tuple_keydef.test.lua
-         COMMAND runtest.sh tuple_keydef.test.lua)
+add_test(
+    NAME tuple_keydef.test.lua
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh tuple_keydef.test.lua)
+
+# Add LUA_CPATH that points to the location, where the built
+# module (tuple/keydef.{so,dylib}) is placed. It is different
+# from the source directory, when out-of-source build is used
+# (`cmake /path/to/sources`, not just `cmake .`).
+#
+# Double semicolons (';;') are replaced with default paths.
+set(TEST_ENV
+    "LUA_CPATH=${CMAKE_CURRENT_BINARY_DIR}/../?${CMAKE_SHARED_LIBRARY_SUFFIX}\\\;\\\;")
+set_tests_properties(tuple_keydef.test.lua PROPERTIES ENVIRONMENT ${TEST_ENV})

--- a/test/tuple_keydef.test.lua
+++ b/test/tuple_keydef.test.lua
@@ -1,6 +1,15 @@
 #!/usr/bin/env tarantool
 
 -- Prefer the module from the repository.
+--
+-- It correctly finds the module, when in-source build is used
+-- (`cmake .` as opposed to `cmake /path/to/source`). Otherwise
+-- the module should be installed into one of default locations
+-- (rare case for testing) or LUA_CPATH should point to its
+-- location.
+--
+-- You don't need to bother about LUA_CPATH if you're use
+-- `make test` or run the test manually with in-source build.
 local cur_dir = require('fio').abspath(debug.getinfo(1).source:match("@?(.*/)")
     :gsub('/%./', '/'):gsub('/+$', ''))
 local soext = jit.os == 'OSX' and 'dylib' or 'so'


### PR DESCRIPTION
There were two problems with out-of-source build around `make test`:

1. The runtest.sh helper script was not found.
2. The built module was not found by the Lua test (`require` failed).

Both are fixed here.

Reported-by: Yaroslav Dynnikov <yaroslav.dynnikov@tarantool.org>