### PR TITLE
Fix hot reload

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,8 @@ add_test(
     NAME tuple_keydef.test.lua
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tuple_keydef.test.lua
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_test(
+    NAME hot_reload.test.lua
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/hot_reload.test.lua
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/hot_reload.test.lua
+++ b/test/hot_reload.test.lua
@@ -1,0 +1,117 @@
+#!/usr/bin/env tarantool
+
+local tap = require('tap')
+local ffi = require('ffi')
+
+-- Presence of the methods confirms that correct metatype is set
+-- for the <struct tuple_keydef> ctype.
+--
+-- Here we don't verify how the methods work.
+local function test_instance_methods_presence(test, tuple_keydef)
+        local methods = {
+            'extract_key',
+            'compare',
+            'compare_with_key',
+            'merge',
+            'totable',
+            '__serialize',
+        }
+        test:plan(#methods)
+
+        local kd = tuple_keydef.new({{fieldno = 1, type = 'unsigned'}})
+        for _, m in ipairs(methods) do
+            test:ok(kd[m] ~= nil, ('%s is present'):format(m))
+        end
+end
+
+-- gh-9: verify hot reload.
+--
+-- https://github.com/tarantool/tuple-keydef/issues/9
+local test = tap.test('hot reload')
+
+test:plan(3)
+
+-- Verify the case, when <struct tuple_keydef> is declared via
+-- LuaJIT's FFI before a first load of the module.
+--
+-- This case looks strange on the first glance, but someone may
+-- declare <struct tuple_keydef> to use ffi.istype(). So it may
+-- be the valid usage.
+--
+-- Important: keep this test case first, don't require the module
+-- before it (otherwise it'll not test anything).
+test:test('declared_ctype', function(test)
+    test:plan(4)
+
+    -- Declare the ctype before first loading of the module.
+    ffi.cdef('struct tuple_keydef')
+
+    -- Verify the first load.
+    local ok, tuple_keydef = pcall(require, 'tuple.keydef')
+    test:ok(ok, 'first load succeeds')
+    test:test('methods presense', test_instance_methods_presence, tuple_keydef)
+
+    -- Verify reload just in case.
+    package.loaded['tuple.keydef'] = nil
+    local ok, tuple_keydef = pcall(require, 'tuple.keydef')
+    test:ok(ok, 'reload succeeds')
+    test:test('methods presense', test_instance_methods_presence, tuple_keydef)
+end)
+
+-- Verify the case, when there are alive links to the previous
+-- module table.
+test:test('hot_reload_keep_old_table', function(test)
+    test:plan(3)
+
+    -- Reload.
+    local tuple_keydef_old = require('tuple.keydef')
+    package.loaded['tuple.keydef'] = nil
+    local ok, tuple_keydef_new = pcall(require, 'tuple.keydef')
+
+    -- Verify.
+    --
+    -- It does not matter, whether the module table is the same or
+    -- a new one.
+    test:ok(ok, 'reload succeeds')
+    test:istable(tuple_keydef_new, 'the module is a table (just in case)')
+
+    -- Fake usage of tuple_keydef_old. Just to hide it from
+    -- LuaJIT's optimizer. I don't know whether it may eliminate
+    -- the variable in this particular case (without the fake
+    -- usage). But in some cases the optimizer is powerful enough:
+    --
+    -- https://gist.github.com/mejedi/d61752c5fd582d2507360d375513c6b8
+    test:istable(tuple_keydef_old, 'fake usage of the old module table')
+end)
+
+-- Collect the old module table before load the module again.
+test:test('hot_reload_after_gc', function(test)
+    test:plan(4)
+
+    require('tuple.keydef')
+
+    -- Forget all links to the module table.
+    --
+    -- rawset() is to don't be hit by the 'strict mode'. When
+    -- tarantool is built as Debug, it behaves like after
+    -- `require('strict').on()` by default.
+    rawset(_G, 'tuple', nil)
+    package.loaded['tuple.keydef'] = nil
+
+    -- Ensure the module table is garbage collected.
+    --
+    -- There is opinion that collectgarbage() should be called
+    -- twice to actually collect everything.
+    --
+    -- https://stackoverflow.com/a/28320364/1598057
+    collectgarbage()
+    collectgarbage()
+
+    local ok, tuple_keydef = pcall(require, 'tuple.keydef')
+    test:ok(ok, 'reload succeeds')
+    test:istable(tuple_keydef, 'the module is a table (just in case)')
+    test:istable(_G.tuple, '_G.tuple is present')
+    test:istable(_G.tuple.keydef, '_G.tuple.keydef is present')
+end)
+
+os.exit(test:check() and 0 or 1)

--- a/tuple/keydef.c
+++ b/tuple/keydef.c
@@ -636,6 +636,8 @@ lbox_key_def_new(struct lua_State *L)
 LUA_API int
 luaopen_tuple_keydef(struct lua_State *L)
 {
+	static bool first_load = true;
+
 	/*
 	 * ffi.metatype() cannot be called twice on the same type.
 	 *
@@ -663,7 +665,10 @@ luaopen_tuple_keydef(struct lua_State *L)
 	luaL_register(L, "tuple.keydef", meta);
 
 	/* Execute Lua part of the module. */
-	execute_postload_lua(L);
+	if (first_load) {
+		execute_postload_lua(L);
+		first_load = false;
+	}
 
 	return 1;
 }

--- a/tuple/postload.lua
+++ b/tuple/postload.lua
@@ -1,3 +1,8 @@
+-- This script is executed only on the first load of the module.
+--
+-- It is NOT executed after hot reload (when the package.loaded
+-- entry is removed and require is called once again).
+
 local ffi = require('ffi')
 local tuple_keydef = require('tuple.keydef')
 local tuple_keydef_t = ffi.typeof('struct tuple_keydef')
@@ -11,6 +16,9 @@ local methods = {
     ['__serialize'] = tuple_keydef.totable,
 }
 
+-- ffi.metatype() succeeds only when called the first time.
+-- Next calls on the same type will raise 'cannot change a
+-- protected metatable' error.
 ffi.metatype(tuple_keydef_t, {
     __index = function(self, key)
         return methods[key]


### PR DESCRIPTION
The scenario is the following:

```lua
require('tuple.keydef')
package.loaded['tuple.keydef'] = nil
require('tuple.keydef')
```

Before this commit we called ffi.metatype() for `struct tuple_keydef` on
each (re)load of the module. LuaJIT does not allow to call it twice for
the same type: it raises a Lua error and reloading of the module fails.

The fix is implemented in the way that does not break ability to declare
`struct tuple_keydef` using ffi.cdef() prior to a first load of the
module. One may need it to implement some general code that uses
ffi.istype() on a particular set of known types. Or for something else.
Anyway, it does not look as something definitely invalid, so I prefer to
stay on the safe side.

A couple of words about test cases. I added a test case that verifies
that the module is reloaded without errors, when there are alive links
to the old module table, as well as the opposite case: when all such
links are collected. In fact, the module don't handle any of such cases
specifically, so it is redundant. Just for the sake of completeness of
the testing.

Fixes #9