### PR TITLE
Don't spoil _G.tuple global variable

### DIFF
--- a/test/hot_reload.test.lua
+++ b/test/hot_reload.test.lua
@@ -86,16 +86,11 @@ end)
 
 -- Collect the old module table before load the module again.
 test:test('hot_reload_after_gc', function(test)
-    test:plan(4)
+    test:plan(2)
 
     require('tuple.keydef')
 
     -- Forget all links to the module table.
-    --
-    -- rawset() is to don't be hit by the 'strict mode'. When
-    -- tarantool is built as Debug, it behaves like after
-    -- `require('strict').on()` by default.
-    rawset(_G, 'tuple', nil)
     package.loaded['tuple.keydef'] = nil
 
     -- Ensure the module table is garbage collected.
@@ -110,8 +105,6 @@ test:test('hot_reload_after_gc', function(test)
     local ok, tuple_keydef = pcall(require, 'tuple.keydef')
     test:ok(ok, 'reload succeeds')
     test:istable(tuple_keydef, 'the module is a table (just in case)')
-    test:istable(_G.tuple, '_G.tuple is present')
-    test:istable(_G.tuple.keydef, '_G.tuple.keydef is present')
 end)
 
 os.exit(test:check() and 0 or 1)

--- a/test/tuple_keydef.test.lua
+++ b/test/tuple_keydef.test.lua
@@ -270,7 +270,7 @@ local tuple_keydef_new_cases = {
 
 local test = tap.test('tuple.keydef')
 
-test:plan(#tuple_keydef_new_cases - 1 + 9)
+test:plan(#tuple_keydef_new_cases - 1 + 10)
 for _, case in ipairs(tuple_keydef_new_cases) do
     if type(case) == 'function' then
         case()
@@ -655,6 +655,18 @@ test:test('no segfault at incorrect key in :compare_with_key()', function(test)
                           {1, 2, 3, 4, 5, 6, 7, 8, 9})
     test:is_deeply({ok, tostring(res)}, {false, exp_err},
                    'Invalid key part count')
+end)
+
+-- The module must not assign the 'tuple' global.
+--
+-- IOW, luaL_register() must have NULL as the second parameter.
+test:test('no _G.tuple', function(test)
+    test:plan(1)
+
+    -- rawget() is to don't be hit by the 'strict mode'. When
+    -- tarantool is built as Debug, it behaves like after
+    -- `require('strict').on()` by default.
+    test:ok(rawget(_G, 'tuple') == nil, '_G.tuple is nil')
 end)
 
 os.exit(test:check() and 0 or 1)

--- a/tuple/postload.lua
+++ b/tuple/postload.lua
@@ -1,10 +1,16 @@
--- This script is executed only on the first load of the module.
+-- This script is NOT a regular module file.
+--
+-- It is bundled into the .so / .dylib file.
+--
+-- It is executed only on the first load of the module.
 --
 -- It is NOT executed after hot reload (when the package.loaded
 -- entry is removed and require is called once again).
+--
+-- The tuple.keydef module table is accessible as `...`.
 
 local ffi = require('ffi')
-local tuple_keydef = require('tuple.keydef')
+local tuple_keydef = ...
 local tuple_keydef_t = ffi.typeof('struct tuple_keydef')
 
 local methods = {


### PR DESCRIPTION
It was my mistake. As I remember, I just missed ability to pass the
module table into postload.lua without calling luaL_register() in the
form that sets package.loaded prior returning from the
luaopen_tuple_keydef() function. I don't know why, but I didn't think
that it'll set the global variable in addition to the package.loaded
field (or didn't pay enough attention to that).

I guess, setting a global variable is not what expected from an external
module, when it is loaded. Especially, when the term ('tuple') is so
common.