### PR TITLE
cmake: fail early if no module.h found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(cmake/compiler.cmake)
 include(cmake/utils.cmake)
 
 # Find Tarantool.
-set(TARANTOOL_FIND_REQUIRED ON)
+set(Tarantool_FIND_REQUIRED ON)
 find_package(Tarantool)
 include_directories(${TARANTOOL_INCLUDE_DIRS})
 


### PR DESCRIPTION
Commit f7f84f02a7c177c513dec8786f1bc59a200eafaa ('cmake: fix warning')
causes a little regression: if there is no tarantool/module.h header, we
should fail at the cmake stage. After the fix of the warning we'll fail
only at the building stage (when `make` is called). Here I return the
old behaviour (fail on the `cmake` stage) back.

Follows up #18