### PR TITLE
build: fix compilation against tarantool 2.10.3+

### DIFF
--- a/tuple/keydef.c
+++ b/tuple/keydef.c
@@ -31,6 +31,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <string.h>
 #include <lua.h>
 #include <lauxlib.h>
 #include <tarantool/module.h>


### PR DESCRIPTION
An inclusion of `string.h` header file was removed from `tarantool/module.h` in tarantool 2.10.3, see https://github.com/tarantool/tarantool/pull/7663.

This module uses `strstr()`, `strlen()` and `memcpy()` functions defined by `string.h`, so it must include this header.

The problem affects the `Debug` build type, which is default for the `cmake . && make` build flow (it is usually used by developers of the module). This build type adds `-Werror` compilation flag. However the problem doesn't affect the `tarantoolctl rocks install tuple-keydef [<version>]` build flow, because it uses the `RelWithDebInfo` build type. All compiler warnings are just warnings here.

Fixes #24