### PR TITLE
ci: workaround setup-tarantool problem with Jammy

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -29,7 +29,7 @@ jobs:
           - 'cmake_and_make'
           - 'luarocks'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install tarantool ${{ matrix.tarantool }}
         uses: tarantool/setup-tarantool@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Use Ubuntu Focal for jobs, where setup-tarantool is used, because there is known unsolved problem with Ubuntu Jammy:
https://github.com/tarantool/setup-tarantool/issues/36