### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,16 @@ on:
     tags: ['*']
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'tuple.keydef'
+
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
@@ -18,6 +28,7 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: version-check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build.luarocks/
 extra/txt2c
 *.lua.c
 *.so
+*.dylib
 
 # Vim Swap files
 .*.sw[a-z]

--- a/tuple/keydef.c
+++ b/tuple/keydef.c
@@ -36,6 +36,7 @@
 #include <lauxlib.h>
 #include <tarantool/module.h>
 #include "util.h"
+#include "keydef_version.h"
 
 /*
  * Verify that <box_key_part_def_t> has the same size when
@@ -684,6 +685,9 @@ luaopen_tuple_keydef(struct lua_State *L)
 	};
 	lua_createtable(L, 0, lengthof(meta) - 1);
 	luaL_register(L, NULL, meta);
+
+	lua_pushstring(L, TUPLE_KEYDEF_VERSION);
+	lua_setfield(L, -2, "_VERSION");
 
 	/* Execute Lua part of the module. */
 	if (first_load) {

--- a/tuple/keydef_version.h
+++ b/tuple/keydef_version.h
@@ -1,0 +1,10 @@
+#ifndef TUPLE_KEYDEF_VERSION_H_INCLUDED
+#define TUPLE_KEYDEF_VERSION_H_INCLUDED
+/*
+* Сontains the module version.
+* Requires manual update in case of release commit.
+*/
+
+#define TUPLE_KEYDEF_VERSION "0.0.4"
+
+#endif /* TUPLE_KEYDEF_VERSION_H_INCLUDED */


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204